### PR TITLE
add GA to production only [RFR]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ View the project at [www.patrimoniomedellin.com](http://www.patrimoniomedellin.c
 
 The Unity of Memory and Heritage, a program of the Medellín Mayor’s Office, wanted a web application with an enriching, easy-to-navigate interface that provides locals and visitors with a way of searching and locating all the 400+ sculptures and architectural sites that are part of the Medellín’s cultural heritage. Mobility Labs' solution is built on top of the Leaflet JavaScript library, using React and GeoJSON for the data. It displays a map of Medellín using a client-suggested color scheme. Different icons are used to indicate the type of heritage (sculpture or archeological finding) at a location. By clicking on the icons, users can access pictures and basic descriptions. Users can also use the predictive search feature to find heritage objects.
 
-###Technical Instructions:
+##Technical Instructions:
+
+###Google Analytics
 
 You will need to create a config.json file in the /client folder.  This will contain your google analytics code, as follows: 
 
@@ -13,8 +15,13 @@ You will need to create a config.json file in the /client folder.  This will con
   "google_analytics_id":"UA-xxxxxx"
 }
 ```
+The analytics code will not be added during development.  To add Google Analytics during production, run the following command:
 
-To run the app: 
+```
+$ gulp copy --production
+```
+
+###To run the app: 
 
 * clone the repo to your local system
 * switch to /client

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -12,6 +12,9 @@ var merge       = require('merge');
 var less        = require('gulp-less');
 var path        = require('path');
 var htmlreplace = require('gulp-html-replace');
+var gulpif      = require('gulp-if');
+var argv        = require('yargs').argv;
+var production  = !!(argv.production); // true if --production
 
 var config      = require('./config.json');
 
@@ -41,13 +44,13 @@ gulp.task('less', function () {
 
 gulp.task('copy', function () {
   gulp.src('./src/index.html')
-    .pipe(
+    .pipe(gulpif(production,
       htmlreplace({
         analytics: {
           src: config.google_analytics_id,
           tpl: '<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","//www.google-analytics.com/analytics.js","ga");ga("create", "%s", "auto");ga("send", "pageview");</script>'
         }
-      })
+      }))
     )
     .pipe(gulp.dest('./dist'));
 

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,8 @@
     "reflux": "^0.2.7",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.0.0",
-    "gulp-html-replace": "^1.5.1"
+    "gulp-html-replace": "^1.5.1",
+    "yargs": "^3.15.0",
+    "gulp-if": "^1.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mobility Labs",
   "license": "ISC",
   "scripts": {
-    "postinstall": "cd ./server && npm install && cd ../client && npm install && node_modules/.bin/gulp && gulp copy --production",
+    "postinstall": "cd ./server && npm install && cd ../client && npm install && node_modules/.bin/gulp --production",
     "start": "node ./server/server.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mobility Labs",
   "license": "ISC",
   "scripts": {
-    "postinstall": "cd ./server && npm install && cd ../client && npm install && node_modules/.bin/gulp",
+    "postinstall": "cd ./server && npm install && cd ../client && npm install && node_modules/.bin/gulp && gulp copy --production",
     "start": "node ./server/server.js"
   }
 }


### PR DESCRIPTION
I set it up so the GA only gets run in production by running a specific gulp command.  This is branched off of analytics so it should be merged to there before analytics is merged to master.
